### PR TITLE
fix: change CICD from release created to published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish-on-Release
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish-npm:


### PR DESCRIPTION
Release `Created` will trigger on draft releases and a second time when a draft release is switched to `Published`.

With release criteria scoped to `Published`, NPM publishing will only occur when a Github release is fully saved (in a non-draft state).